### PR TITLE
Fix email header in password recovery

### DIFF
--- a/backend/app/api/routes/login.py
+++ b/backend/app/api/routes/login.py
@@ -120,5 +120,5 @@ def recover_password_html_content(email: str, session: SessionDep) -> Any:
     )
 
     return HTMLResponse(
-        content=email_data.html_content, headers={"subject:": email_data.subject}
+        content=email_data.html_content, headers={"subject": email_data.subject}
     )


### PR DESCRIPTION
## Summary
- correct header name used in password recovery HTML response

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_684197267f9c8321ad0be33f214c86d2